### PR TITLE
fix for missing link in user_sign_in.feature

### DIFF
--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -37,7 +37,7 @@ Then(/^I should be on the User registration page$/) do
 end
 
 When(/^I fill in "(.*?)" with "(.*?)"$/) do |field, value|
-  fill_in field, with: value
+  fill_in field, with: value, match: :prefer_exact
 end
 
 When(/^I select "([^"]*)" to "([^"]*)"$/) do |field, option|

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -16,6 +16,10 @@ When(/^I visit the site$/) do
   visit root_path
 end
 
+When(/^I visit the "(.*?)" page$/) do |page|
+  visit path_to(page)
+end
+
 When(/^I (?:go to|am on) the "([^"]*)" page$/) do |page|
   visit path_to(page)
 end

--- a/features/user_registration.feature
+++ b/features/user_registration.feature
@@ -4,17 +4,16 @@ Feature: User registration
   So that I can become a THUD member
 
   Background:
-    Given I visit the site
-    And I click "Sign up now"
-    Then I should be on the "user registration" page
+    Given I am not logged in
+    And I visit the "user registration" page
 
   Scenario: Successfully create new profile
-    When I fill in "user_first_name" with "John"
-    And I fill in "user_last_name" with "Doe"
-    And I fill in "user_city" with "Pretoria"
-    And I fill in "user_email" with "johndoe@example.com"
-    And I fill in "user_password" with "password"
-    And I fill in "user_password_confirmation" with "password"
+    When I fill in "First name" with "John"
+    And I fill in "Last name" with "Doe"
+    And I fill in "City" with "Pretoria"
+    And I fill in "Email" with "johndoe@example.com"
+    And I fill in "Password" with "password"
+    And I fill in "Password confirmation" with "password"
     And I select "user_member_type" to "Entrepreneur"
     And I accept the terms and conditions
     And I click "Sign up"
@@ -23,12 +22,12 @@ Feature: User registration
     # When I follow the confirmation link in the confirmation email
 
   Scenario: User enters an incorrect email address
-    When I fill in "user_email" with "aa@dd"
+    When I fill in "Email" with "aa@dd"
     And I click "Sign up"
     Then I should see "is invalid"
 
   Scenario: User's password and password confirmation are not matching
-    When I fill in "user_password" with "password"
-    Then I fill in "user_password_confirmation" with "Pas$w0rd"
+    When I fill in "Password" with "password"
+    Then I fill in "Password confirmation" with "Pas$w0rd"
     And I click "Sign up"
     Then I should see "doesn't match Password"

--- a/features/user_sign_in.feature
+++ b/features/user_sign_in.feature
@@ -9,24 +9,22 @@ Feature: User sign_in
       | John       | Doe       | john@example.com | password | Entrepreneur | pretoria |
 
     Given I am not logged in
-    When I visit the site
-    And I click "Sign in"
-    Then I should be on the "user login" page
+    And I visit the "user login" page
 
   Scenario: Successfull login
-    When I fill in "user_email" with "john@example.com"
-    And I fill in "user_password" with "password"
+    When I fill in "Email" with "john@example.com"
+    And I fill in "Password" with "password"
     And I click "Log in"
     Then I should see "Signed in successfully"
 
   Scenario: User provides wrong email address
-    When I fill in "user_email" with "john1@example.com"
-    And I fill in "user_password" with "password"
+    When I fill in "Email" with "john1@example.com"
+    And I fill in "Password" with "password"
     And I click "Log in"
     Then I should see "Invalid email or password"
 
   Scenario: User provides wrong email address
-    When I fill in "user_email" with "john@example.com"
-    And I fill in "user_password" with "pa$ssword"
+    When I fill in "Email" with "john@example.com"
+    And I fill in "Password" with "pa$ssword"
     And I click "Log in"
     Then I should see "Invalid email or password"


### PR DESCRIPTION
- I go straight to the sign in page rather then letting capybara visit the root and search for links. If you want to test that functionality that should be in a scenario by itself not in a background. In my opinion the background should set the stage for the scenarions only, and not contain any tests. Does that make sense?
- Cukes are for non-technical ppl. Try using the labels rather then class names when identifying input fields.
